### PR TITLE
Improved creation of caching directory

### DIFF
--- a/BladeOne.php
+++ b/BladeOne.php
@@ -198,14 +198,23 @@ class BladeOne
     //<editor-fold desc="constructor">
     /**
      * Bob the constructor.
+	 * 
+	 * The folder at $compiledPath is created in case it doesn't exist.
      *
-     * @param  string $templatePath
-     * @param $compiledPath
+     * @param string $templatePath
+     * @param string $compiledPath
      */
     public function __construct($templatePath, $compiledPath)
     {
         $this->templatePath = $templatePath;
         $this->compiledPath = $compiledPath;
+		
+		if (!file_exists($this->compiledPath)) {
+			$ok = @mkdir($this->compiledPath, 0777, true);
+			if (!$ok) {
+				$this->showError("Constructing", "Unable to create the compile folder [{$this->compiledPath}]. Check the permissions of it's parent folder.", true);
+			}
+		}
     }
     //</editor-fold>
 
@@ -307,13 +316,6 @@ class BladeOne
             $contents = $this->compileString($this->getFile($template));
 
             if (!is_null($this->compiledPath)) {
-                $dir = dirname($compiled);
-                if (!file_exists($dir)) {
-                    $ok = @mkdir($dir, 0777, true);
-                    if (!$ok) {
-                        $this->showError("Compiling","Unable to create the compile folder [{$dir}]. Check the permissions of it's parent folder.", true);
-                    }
-                }
                 $ok = @file_put_contents($compiled, $contents);
                 if (!$ok) {
                     $this->showError("Compiling","Unable to save the file [{$fileName}]. Check the compile folder is defined and has the right permission");

--- a/BladeOne.php
+++ b/BladeOne.php
@@ -301,7 +301,7 @@ class BladeOne
             $this->fileName = $fileName;
         }
         $compiled = $this->getCompiledFile();
-        $template=$this->getTemplateFile();
+        $template = $this->getTemplateFile();
         if ($this->isExpired() || $forced) {
             // compile the original file
             $contents = $this->compileString($this->getFile($template));
@@ -309,9 +309,12 @@ class BladeOne
             if (!is_null($this->compiledPath)) {
                 $dir = dirname($compiled);
                 if (!file_exists($dir)) {
-                    @mkdir($dir, 777, true);
+                    $ok = @mkdir($dir, 0777, true);
+                    if (!$ok) {
+                        $this->showError("Compiling","Unable to create the compile folder [{$dir}]. Check the permissions of it's parent folder.", true);
+                    }
                 }
-                $ok=@file_put_contents($compiled, $contents);
+                $ok = @file_put_contents($compiled, $contents);
                 if (!$ok) {
                     $this->showError("Compiling","Unable to save the file [{$fileName}]. Check the compile folder is defined and has the right permission");
                 }

--- a/BladeOne.php
+++ b/BladeOne.php
@@ -44,12 +44,12 @@ class BladeOne
      */
     protected $fileName;
 
-	/**
-	 * File extension for the template files.
-	 *
-	 * @var string
-	 */
-	protected $fileExtension = '.blade.php';
+    /**
+     * File extension for the template files.
+     *
+     * @var string
+     */
+    protected $fileExtension = '.blade.php';
 
     /**
      * The stack of in-progress sections.
@@ -307,10 +307,10 @@ class BladeOne
             $contents = $this->compileString($this->getFile($template));
 
             if (!is_null($this->compiledPath)) {
-            	$dir = dirname($compiled);
-				if (!file_exists($dir)) {
-					@mkdir($dir, 777, true);
-				}
+                $dir = dirname($compiled);
+                if (!file_exists($dir)) {
+                    @mkdir($dir, 777, true);
+                }
                 $ok=@file_put_contents($compiled, $contents);
                 if (!$ok) {
                     $this->showError("Compiling","Unable to save the file [{$fileName}]. Check the compile folder is defined and has the right permission");

--- a/BladeOne.php
+++ b/BladeOne.php
@@ -198,8 +198,8 @@ class BladeOne
     //<editor-fold desc="constructor">
     /**
      * Bob the constructor.
-	 * 
-	 * The folder at $compiledPath is created in case it doesn't exist.
+     * 
+     * The folder at $compiledPath is created in case it doesn't exist.
      *
      * @param string $templatePath
      * @param string $compiledPath
@@ -208,13 +208,13 @@ class BladeOne
     {
         $this->templatePath = $templatePath;
         $this->compiledPath = $compiledPath;
-		
-		if (!file_exists($this->compiledPath)) {
-			$ok = @mkdir($this->compiledPath, 0777, true);
-			if (!$ok) {
-				$this->showError("Constructing", "Unable to create the compile folder [{$this->compiledPath}]. Check the permissions of it's parent folder.", true);
-			}
-		}
+
+        if (!file_exists($this->compiledPath)) {
+            $ok = @mkdir($this->compiledPath, 0777, true);
+            if (!$ok) {
+                $this->showError("Constructing", "Unable to create the compile folder [{$this->compiledPath}]. Check the permissions of it's parent folder.", true);
+            }
+        }
     }
     //</editor-fold>
 


### PR DESCRIPTION
My first implementation for automagically creating the caching directory was working, but not optimal. It checks the directory for every template loaded. Nevertheless it should be enough to check and eventually create it once in the constructor when it's first specified. That's enough as long as it is not changed afterwards. This is a minor improvement for (probably) v1.9, but decreases file API calls.