### PR TITLE
Change the implementation of `@inject` to allow for custom class resolving.

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,13 +405,29 @@ The current value is 8
 The current value is 9
 ```
 
-#### @inject('class',['namespace'])
+#### @inject('variable name', 'namespace')
 
 ```html
 @inject('metric', 'App\Services\MetricsService')
 <div>
     Monthly Revenue: {{ $metric->monthlyRevenue() }}.
 </div>
+```
+
+By default BladeOne creates a new instance of the class `'variable name'` inside `'namespace'` with the parameterless contructor.
+
+To override the logic used to resolve injected classes, pass a function to `setInjectResolver`.
+
+
+Example with Symphony Dependency Injection.
+```php
+$containerBuilder = new ContainerBuilder();
+$loader = new XmlFileLoader($containerBuilder, new FileLocator(__DIR__));
+$loader->load('services.xml');
+
+$blade->setInjectResolver(function ($namespace, $variableName) use ($loader) {
+    return $loader->get($namespace);
+});
 ```
 
 

--- a/examples/testinjectcustom.php
+++ b/examples/testinjectcustom.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services {
+
+	class SimpleClass {
+		private $varName;
+		function __construct($varName) {
+			$this->varName = $varName;
+		}
+
+		function ping($pong) {
+			return "[$this->varName] $pong";
+		}
+	}
+
+}
+
+namespace {
+	include "../lib/BladeOne.php";
+
+	use eftec\bladeone\BladeOne;
+
+	$views = __DIR__ . '/views';
+	$compiledFolder = __DIR__ . '/compiled';
+	$blade = new BladeOne($views, $compiledFolder, BladeOne::MODE_SLOW);
+	$blade->setInjectResolver(function ($className, $varName) {
+		$fullClassName = "App\\Services\\$className";
+		return new $fullClassName($varName);
+	});
+
+
+	$records = array(1, 2, 3);
+
+	include "service/Metric.php";
+
+
+	try {
+		echo $blade->run("Test.inject2"
+			, ["name" => "hello"
+				, 'records' => $records
+				, 'emptyArray' => array()
+			]);
+
+	} catch (Exception $e) {
+		echo $e->getMessage();
+	}
+
+}

--- a/examples/views/Test/inject2.blade.php
+++ b/examples/views/Test/inject2.blade.php
@@ -1,0 +1,18 @@
+@set($x1=20)
+Injection:<hr>
+@inject("metric" , 'MetricsService\Metric')
+@inject("simpleclass" ,'SimpleClass')
+<hr>
+<div>
+    Monthly Revenue: {{ $metric->monthlyRevenue() }}.
+</div>
+<div>
+    Ping: {{ $simpleclass->ping('pong!') }}.
+</div>
+
+
+@inject("ohterSimpleClass", "SimpleClass")
+
+<div>
+    Ping Again: {{ $ohterSimpleClass->ping('pong again!') }}.
+</div>


### PR DESCRIPTION
The previous behaviour of `@inject` is not changed.

See also EFTEC/BladeOne#42, let me know if you like this approach.

This implementation makes it also possible to make BladeOne's `@inject` work when laravel is also in the project.

```php
$blade->setInjectResolver(function ($className) {
    return app($className);
});

// This should even work.
$blade->setInjectResolver(app);
```
(As seen in https://github.com/illuminate/view/blob/master/Compilers/Concerns/CompilesInjections.php#L21)