### PR TITLE
changed login for setAuth in the below example

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ $views = __DIR__ . '/views';
 $cache = __DIR__ . '/cache';
 $blade=new bladeone\BladeOne($views,$cache,BladeOne::MODE_AUTO);
 
-$blade->login('johndoe','admin'); // where johndoe is an user and admin is the role. The role is optional
+$blade->setAuth('johndoe','admin'); // where johndoe is an user and admin is the role. The role is optional
 
 echo $blade->run("hello",array("variable1"=>"value1"));
 ```


### PR DESCRIPTION
```php
$blade->setAuth('johndoe','admin'); // where johndoe is an user and admin is the role. The role is optional
```

Reason login throws an error whilst setAuth works.