### PR TITLE
Add @error directive and tests

### DIFF
--- a/tests/CanTest.php
+++ b/tests/CanTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace eftec\tests;
+
+/**
+ * @author G.J.W. Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @since  17/09/2018
+ */
+class CanTest extends AbstractBladeTestCase
+{
+    /**
+     * @throws \Exception
+     */
+    public function testNoErrorCallback()
+    {
+        $bladeSource = /** @lang Blade */
+            <<<'BLADE'
+@error('key')
+    Is hidden...
+@enderror
+BLADE;
+        $this->assertEqualsIgnoringWhitespace("", $this->blade->runString($bladeSource, []));
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testErrorCallback()
+    {
+        $bladeSource = /** @lang Blade */
+            <<<'BLADE'
+@error('key')
+    Is hidden...
+@enderror
+BLADE;
+
+        $errorArray = [
+            'key' => 'error string'
+        ];
+
+        $errorCallback = function($key = null) use ($errorArray) {
+            return array_key_exists($key, $errorArray);
+        };
+
+        $this->blade->setErrorFunction($errorCallback);
+
+        $this->assertEqualsIgnoringWhitespace("Is hidden...", $this->blade->runString($bladeSource, []));
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testInlineErrorCallback()
+    {
+        $bladeSource = /** @lang Blade */
+            <<<'BLADE'
+<div class="@error('key') extra-class @enderror"></div>
+BLADE;
+
+        $errorArray = [
+            'key' => 'error string'
+        ];
+
+        $errorCallback = function($key = null) use ($errorArray) {
+            return array_key_exists($key, $errorArray);
+        };
+
+        $this->blade->setErrorFunction($errorCallback);
+
+        $this->assertEquals('<div class=" extra-class "></div>', $this->blade->runString($bladeSource, []));
+    }
+
+}


### PR DESCRIPTION
I noticed that we had no support for `@error`, so I created this PR to provide it.

I created a new method to allow developers to set their callback to handle the error checking:

```` php
$blade->setErrorFunction(function($key) {
    return \CustomErrorClass::has($key);
});
````
As you can see it works the same as the `setCanFunction()`, `setAnyFunction()` methods already present.

This then allows a developer to use it as per the [Laravel docs](https://laravel.com/docs/5.8/blade#validation-errors):

```` blade
<label for="title">Post Title</label>

<input id="title" type="text" class="@error('title') is-invalid @enderror">

@error('title')
    <div class="alert alert-danger">{{ $message }}</div>
@enderror
````

All additional code has passing tests with 100% coverage.
