### PR TITLE
Fix throwOnError

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -293,7 +293,7 @@ class BladeOne
     public function showError($id, $text, $critic = false, $alwaysThrow = false)
     {
         \ob_get_clean();
-        if (($this->throwOnError || $alwaysThrow) && $critic === true) {
+        if ($this->throwOnError || $alwaysThrow || $critic === true) {
             throw new \RuntimeException("BladeOne Error [$id] $text");
         } else {
             echo "<div style='background-color: red; color: black; padding: 3px; border: solid 1px black;'>";


### PR DESCRIPTION
Error doesn't need to be critical to be thrown.

At the same time, critical errors are still thrown even if throwOnError is not set.