### PR TITLE
[4.x] PHP 8.1 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 composer.lock
 vendor/
 tests/resources/compiled/
-\.php_cs\.cache
+*.cache

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,6 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5.20"
+    "phpunit/phpunit": "^8.0"
   }
 }

--- a/tests/BladeOneLangTest.php
+++ b/tests/BladeOneLangTest.php
@@ -13,7 +13,7 @@ use eftec\bladeone\BladeOneLang;
  */
 class BladeOneLangTest extends AbstractBladeTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->blade = new BladeOne(
             self::TEMPLATE_PATH,
@@ -148,4 +148,3 @@ class BladeOneLangTest extends AbstractBladeTestCase
         $this->assertEquals(\filesize($this->blade->missingLog), 4);
     }
 }
-

--- a/tests/NullEscapeTest.php
+++ b/tests/NullEscapeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace eftec\tests;
+
+class NullEscapeTest extends AbstractBladeTestCase
+{
+    public function test_returns_empty_string_when_escaping_null_value()
+    {
+        $this->assertEquals(
+            '',
+            $this->blade::e(null)
+        );
+    }
+}


### PR DESCRIPTION
## Changed

- PHP 8.1 Support
- Prevent error messages when escaping null values

 ## Fixed

- `$variablesGlobal` type
-  `ParseError` namespace