### PR TITLE
Allowing Numbers

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -338,7 +338,7 @@ class BladeOne
         if (\is_null($value)) {
             return '';
         }
-        if (is_numeric($value)) {
+        if (\is_numeric($value)) {
             return self::e(strval($value));
         }
         if (\is_array($value) || \is_object($value)) {

--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -329,7 +329,7 @@ class BladeOne
     /**
      * Escape HTML entities in a string.
      *
-     * @param string|null $value
+     * @param int|string|null $value
      * @return string
      */
     public static function e($value): string
@@ -338,7 +338,9 @@ class BladeOne
         if (\is_null($value)) {
             return '';
         }
-
+        if (is_numeric($value)) {
+            return self::e(strval($value));
+        }
         if (\is_array($value) || \is_object($value)) {
             return \htmlentities(\print_r($value, true), ENT_QUOTES, 'UTF-8', false);
         }


### PR DESCRIPTION
Just had an error when printing a pure number and thought it would be nice if the {{ }} method wasnt restricted to strings, as it can already handle both array and objects. Int´s would be nice too i think.