### PR TITLE
Export-Ignore Markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,5 @@
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore
+/*.md               export-ignore
 /phpunit.xml        export-ignore


### PR DESCRIPTION
This will exclude all Markdown files in production when the package is downloaded.