### PR TITLE
BladeOne::getCompiledFile's hashes should include the full template path #165

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -148,11 +148,10 @@ class BladeOne
     /** @var string the extension of the compiled file. */
     protected $compileExtension = '.bladec';
     /**
-     * @var string=['auto','sha1','md5','nochange'][$i] It determines how the compiled filename will be called.<br>
-     *            <b>auto</b> (default mode) the mode is "sha1" unless the mode is MODE_DEBUG<br>
+     * @var string=['auto','sha1','md5'][$i] It determines how the compiled filename will be called.<br>
+     *            <b>auto</b> (default mode) the mode is "sha1"<br>
      *            <b>sha1</b> the filename is converted into a sha1 hash<br>
      *            <b>md5</b> the filename is converted into a md5 hash<br>
-     *            <b>normal</b> the filename is left untouched<br>
      */
     protected $compileTypeFileName='auto';
 
@@ -1266,19 +1265,26 @@ class BladeOne
     public function getCompiledFile($templateName = ''): string
     {
         $templateName = (empty($templateName)) ? $this->fileName : $templateName;
+
+        $fullPath = $this->getTemplateFile($templateName);
+        if($fullPath == '') {
+            throw new \RuntimeException('Template not found: ' . $templateName);
+        }
+
         $style=$this->compileTypeFileName;
         if ($style==='auto') {
-            $style=($this->getMode() === self::MODE_DEBUG)?'nochange':'sha1';
+            $style='sha1';
         }
+
         switch ($style) {
-            case 'normal':
-                return $this->compiledPath . '/' . $templateName . $this->compileExtension;
             case 'md5':
-                return $this->compiledPath . '/' . \md5($templateName) . $this->compileExtension;
-            case 'sha1':
-                return $this->compiledPath . '/' . \sha1($templateName) . $this->compileExtension;
+                $hash = \md5($fullPath);
+                break;
+            default:
+                $hash = \sha1($fullPath);
         }
-        return $this->compiledPath . '/' . $templateName . $this->compileExtension;
+
+        return $this->compiledPath . '/' . basename($templateName) . '_' . $hash . $this->compileExtension;
     }
 
 
@@ -1883,11 +1889,10 @@ class BladeOne
 
     /**
      * It determines how the compiled filename will be called.<br>
-     * <b>auto</b> (default mode) the mode is "sha1" unless the mode is MODE_DEBUG<br>
+     * <b>auto</b> (default mode) the mode is "sha1"<br>
      * <b>sha1</b> the filename is converted into a sha1 hash (it's the slow method, but it is safest)<br>
      * <b>md5</b> the filename is converted into a md5 hash (it's faster than sha1, and it uses less space)<br>
-     * <b>normal</b> the filename is left untouched (it's the fastest mode but the filename could be exposed)<br>
-     * @param string $compileTypeFileName=['auto','sha1','md5','nochange'][$i]
+     * @param string $compileTypeFileName=['auto','sha1','md5'][$i]
      * @return BladeOne
      */
     public function setCompileTypeFileName(string $compileTypeFileName): BladeOne

--- a/tests/CompilationTest.php
+++ b/tests/CompilationTest.php
@@ -24,12 +24,16 @@ class CompilationTest extends AbstractBladeTestCase
         $views = __DIR__ . '/templates';
         $compiledFolder = __DIR__ . '/compiled';
         $blade = new BladeOne($views, $compiledFolder);
+
+        // Type MD5
         $blade->setCompileTypeFileName('md5');
         $this->assertEquals("It is a basic template hello world.\n", $blade->run('basic',['variable'=>'hello world']));
-        $this->assertEquals('f17aaabc20bfe045075927934fed52d2.bladec',basename($blade->getCompiledFile('basic')));
+        $this->assertEquals('basic_' . \md5($views . '/' . 'basic.blade.php') . '.bladec',basename($blade->getCompiledFile('basic')));
+
+        // Type default fallback (type does not exist)
         $blade->setCompileTypeFileName('nochange');
         $this->assertEquals("It is a basic template hello world.\n", $blade->run('basic',['variable'=>'hello world']));
-        $this->assertEquals('basic.bladec',basename($blade->getCompiledFile('basic')));
+        $this->assertEquals('basic_' . \sha1($views . '/' . 'basic.blade.php') . '.bladec',basename($blade->getCompiledFile('basic')));
     }
     public function testComment(): void
     {
@@ -39,7 +43,7 @@ class CompilationTest extends AbstractBladeTestCase
         $blade = new BladeOne($views, $compiledFolder);
         $blade->setCompileTypeFileName('md5');
         $this->assertEquals("Multi line comment in PHP tags\n\nSingle line comment in PHP tags\n\n", $blade->run('comment',[]));
-        $this->assertEquals('06d4cd63bde972fc66a0aed41d2f5c51.bladec',basename($blade->getCompiledFile('comment')));
+        $this->assertEquals('comment_' . \md5($views . '/' . 'comment.blade.php') . '.bladec',basename($blade->getCompiledFile('comment')));
     }
 
     public function testToken(): void
@@ -138,7 +142,7 @@ class CompilationTest extends AbstractBladeTestCase
         $this->blade->setMode(BladeOne::MODE_DEBUG);
         $this->blade->run('compilation.base', []);
 
-        $this->assertFileExists(__DIR__ . '/resources/compiled/compilation.base.bladec');
+        $this->assertFileExists(__DIR__ . '/resources/compiled/compilation.base_' . \sha1(__DIR__ . '/resources/templates/compilation/base.blade.php') . '.bladec');
 
         $this->blade->setMode(BladeOne::MODE_SLOW);
     }
@@ -177,7 +181,7 @@ class CompilationTest extends AbstractBladeTestCase
         $this->blade->setCompiledExtension('.bladeD');
         $this->blade->run('compilation.base', []);
 
-        $this->assertFileExists(__DIR__ . '/resources/compiled/' . sha1('compilation.base') . '.bladeD');
+        $this->assertFileExists(__DIR__ . '/resources/compiled/compilation.base_' . sha1(__DIR__ . '/resources/templates/compilation/base.blade.php') . '.bladeD');
 
         $this->blade->setCompiledExtension('.bladec');
     }

--- a/tests/NoEscapeTest.php
+++ b/tests/NoEscapeTest.php
@@ -14,7 +14,7 @@ class NoEscapeTest extends AbstractBladeTestCase {
     public function testCompilationDebugCreatesCompiledFile() {
         $this->blade->setMode(BladeOne::MODE_DEBUG);
         $this->blade->run('compilation.noescape', []);
-        $this->assertFileEquals(__DIR__ . '/resources/compiled/compilation.noescape.bladec',
+        $this->assertFileEquals(__DIR__ . '/resources/compiled/compilation.noescape_' . \sha1(__DIR__ . '/resources/templates/compilation/noescape.blade.php') . '.bladec',
             __DIR__ . '/resources/templates/compilation/noescape.blade.php');
         $this->blade->setMode(BladeOne::MODE_SLOW);
     }


### PR DESCRIPTION
see #165 

As a result:
Compile filename type "normale" and "nochange" merged into "auto" and removed