### PR TITLE
Fix: CompileEchoDefaults should not compile method calls

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -3114,13 +3114,18 @@ class BladeOne
 
     /**
      * Compile the default values for the echo statement.
+     * Example:
+     * {{ $test or 'test2' }} compiles to {{ isset($test) ? $test : 'test2' }}
      *
      * @param string $value
      * @return string
      */
     protected function compileEchoDefaults($value): string
     {
-        $result = \preg_replace('/^(?=\$)(.+?)\s+or\s+(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+        // Source: https://www.php.net/manual/en/language.variables.basics.php
+        $patternPHPVariableName = '\$[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*';
+
+        $result = \preg_replace('/^(' . $patternPHPVariableName . ')\s+or\s+(.+?)$/s', 'isset($1) ? $1 : $2', $value);
         if (!$this->pipeEnable) {
             return $this->fixNamespaceClass($result);
         }

--- a/tests/VariablesTest.php
+++ b/tests/VariablesTest.php
@@ -128,4 +128,27 @@ BLADE;
 BLADE;
         $this->assertEqualsIgnoringWhitespace("{{ \$var }}", $this->blade->runString($bladeString, ["var" => "my_var"]));
     }
+
+    public function testDefaultFallback() : void {
+
+        $this->assertEquals('<?php echo \htmlentities(isset($_Name1) ? $_Name1 : \'Default\'??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ $_Name1 or \'Default\' }}'));
+        $this->assertEquals('<?php echo isset($_Name1) ? $_Name1 : \'Default\'; ?>', $this->blade->compileString('{!! $_Name1 or \'Default\' !!}'));
+        $this->assertEquals('<?php echo isset($_Name1) ? $_Name1 : "Default"; ?>', $this->blade->compileString('{!! $_Name1 or "Default" !!}'));
+        $this->assertEquals('<?php echo isset($_Name1) ? $_Name1 : fallback("test2"); ?>', $this->blade->compileString('{!! $_Name1 or fallback("test2") !!}'));
+        $this->assertEquals('<?php echo isset($_Name1) ? $_Name1 : fallback(\'test2\'); ?>', $this->blade->compileString('{!! $_Name1 or fallback(\'test2\') !!}'));
+    }
+    
+    public function testNotDefaultFallback() : void
+    {
+        $this->assertEquals('<?php echo \htmlentities(T->method(\'TEST or TEST2\')??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ T->method(\'TEST or TEST2\') }}'));
+        $this->assertEquals('<?php echo function1("TEST or TEST2"); ?>', $this->blade->compileString('{!! function1("TEST or TEST2") !!}'));
+        $this->assertEquals('<?php echo $t("TEST or TEST2"); ?>', $this->blade->compileString('{!! $t("TEST or TEST2") !!}'));
+        $this->assertEquals('<?php echo $t->method("TEST or TEST2"); ?>', $this->blade->compileString('{!! $t->method("TEST or TEST2") !!}'));
+        $this->assertEquals('<?php echo \htmlentities($t->method("TEST or TEST2")??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ $t->method("TEST or TEST2") }}'));
+        $this->assertEquals('<?php echo \htmlentities($t->method(\'TEST or TEST2\')??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ $t->method(\'TEST or TEST2\') }}'));
+        $this->assertEquals('<?php echo \htmlentities(T::staticMethod(\'TEST or TEST2\')??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ T::staticMethod(\'TEST or TEST2\') }}'));
+        $this->assertEquals('<?php echo \htmlentities(T::staticMethod(\'TEST or TEST2\')??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ T::staticMethod(\'TEST or TEST2\') }}'));
+        $this->assertEquals('<?php echo \htmlentities($t::staticMethod(\'TEST or TEST2\')??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ $t::staticMethod(\'TEST or TEST2\') }}'));
+        $this->assertEquals('<?php echo \htmlentities($t::staticMethod(\'TEST or TEST2\')??\'\', ENT_QUOTES, \'UTF-8\', false); ?>', $this->blade->compileString('{{ $t::staticMethod(\'TEST or TEST2\') }}'));
+    }
 }


### PR DESCRIPTION
I discovered, that the tag 
`{!! $t("TEST or TEST2") !!}`

is unexpected processed to:
`<?php echo isset($t("TEST) ? $t("TEST : TEST2"); ?>`

Expected was:
`<?php echo $t("TEST or TEST2"); ?>`

Reason:
The `BladeOne::compileEchoDefaults` regex pattern, matches more cases than expected.

The PR is using the php.net's variable pattern and includes tests.