### PR TITLE
Fix trait collision on BladeOne constructor

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -278,9 +278,13 @@ class BladeOne
         // 2- it must don't have arguments
         // 3- It must have the name of the trait. i.e. trait=MyTrait, method=MyTrait()
         $traits = get_declared_traits();
+        $currentTraits = (array) class_uses($this);
         foreach ($traits as $trait) {
             $r = explode('\\', $trait);
             $name = end($r);
+            if (!in_array($trait, $currentTraits, true)) {
+                continue;
+            }
             if (is_callable([$this, $name]) && method_exists($this, $name)) {
                 $this->{$name}();
             }


### PR DESCRIPTION
This pull request addresses a trait collision problem within the BladeOne constructor.

The constructor now incorporates a verification step to ensure that a trait is actually in use before invoking its corresponding named method. This modification prevents errors from traits sharing the same name as methods within the BladeOne class.

The specific scenario prompting this adjustment involves a collision between a trait called 'With', utilized in another library, and the 'BladeOne::with()' method.