### PR TITLE
Fixed an error when passing an array to addAssetDict

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -187,7 +187,7 @@ class BladeOne
     /** @var string it is a relative path calculated between baseUrl and the current url. Example ../../ */
     protected string $relativePath = '';
     /** @var string[] Dictionary of assets */
-    protected ?array $assetDict;
+    protected array $assetDict = [];
     /** @var bool if true then it removes tabs and unneeded spaces */
     protected bool $optimize = true;
     /** @var bool if false, then the template is not compiled (but executed on memory). */


### PR DESCRIPTION
Hi, I have the same issue as https://github.com/EFTEC/BladeOne/issues/128.
`Fatal error: Uncaught Error: Typed property eftec\bladeone\BladeOne::$assetDict must not be accessed before initialization in <...path...>\vendor\eftec\bladeone\lib\BladeOne.php:842`
I see it was fixed but appeared again after this recent change https://github.com/EFTEC/BladeOne/commit/8e5aec843a518d904a595e17065a6c38d4f0c0bb#diff-f808bfcd37fd9d35daadbf9e67567956af3388ea1d6aea83f6a94497a98e4cbcR190
So here I'm just fixing a line with `$assetDict` property declaration.
Would love to have this available in the next version.
Thanks in advance :)