### PR TITLE
Update BladeOne.php

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -2887,7 +2887,7 @@ class BladeOne
         $pattern = "/" . $this->contentTags[0] . "--(.*?)--" . $this->contentTags[1] . "/s";
         switch ($this->commentMode) {
             case 0:
-                return \preg_replace($pattern, $this->phpTag . '/*$1*/ ? >', $value);
+                return \preg_replace($pattern, $this->phpTag . '/*$1*/ ?>', $value);
             case 1:
                 return \preg_replace($pattern, '<!-- $1 -->', $value);
             default:


### PR DESCRIPTION
space symbol between '?' and '>' produced php parsing error during running cached file.

Fixing...

This is forks for me.