### PR TITLE
Fix regex to match quoted parameters in parseParams function

### DIFF
--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -3033,7 +3033,7 @@ class BladeOne
 
     protected function parseParams($params): string
     {
-        preg_match_all('/([a-zA-Z0-9:-]*?)\s*?=\s*?(.+?)(\s|$)/ms', $params, $matches);
+        preg_match_all('/([a-zA-Z0-9:-]*?)\s*?=\s*?(".+?"|\'.+?\')(\s|$)/ms', $params, $matches);
         $paramsCompiled = [];
         foreach ($matches[1] as $i => $key) {
             $value = str_replace('"', '', $matches[2][$i]);

--- a/lib/BladeOne.php
+++ b/lib/BladeOne.php
@@ -3033,7 +3033,7 @@ class BladeOne
 
     protected function parseParams($params): string
     {
-        preg_match_all('/([a-zA-Z0-9:-]*?)\s*?=\s*?(".+?"|\'.+?\')(\s|$)/ms', $params, $matches);
+        preg_match_all('/([a-zA-Z0-9:-]*?)\s*?=\s*?("?.+?"?|\'?.+?\'?)(\s|$)/ms', $params, $matches);
         $paramsCompiled = [];
         foreach ($matches[1] as $i => $key) {
             $value = str_replace('"', '', $matches[2][$i]);


### PR DESCRIPTION
This pull request updates the parameter parsing logic in the `parseParams` method to better handle quoted parameter values. The regular expression used for matching parameters now supports values wrapped in either single or double quotes, improving robustness when parsing parameters with spaces or special characters.

Improvements to parameter parsing:

* Updated the regular expression in `parseParams` to correctly match parameter values enclosed in single or double quotes, enhancing support for complex parameter values.